### PR TITLE
Re-adding build script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "React Native SDK for the Berbix Verify flow",
   "main": "index.js",
   "scripts": {
+    "build": "babel src --out-file index.js",
     "webpack": "webpack"
   },
   "repository": {


### PR DESCRIPTION
Not sure why this script got pull out in this commit: https://github.com/berbix/berbix-react-native/commit/2998cb486e49de4d443f3050e3295a150b119a2f#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

But it is needed to build.

@ericlevine 